### PR TITLE
Fix indentation for resources on daemonset manifest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix indentation for `requests` and `limits` on the daemonset manifest.
+
 ## [1.24.1-gs1] - 2022-09-13
 
 ### Changed

--- a/helm/aws-cloud-controller-manager-app/templates/daemonset.yaml
+++ b/helm/aws-cloud-controller-manager-app/templates/daemonset.yaml
@@ -30,7 +30,7 @@ spec:
       - name: {{ .Chart.Name }}
         image: "{{ .Values.image.registry }}/{{ .Values.image.name }}:{{ .Values.image.tag }}"
         {{- if .Values.resources }}
-        resources: {{ toYaml .Values.resources | nindent 8 }}
+        resources: {{ toYaml .Values.resources | nindent 10 }}
         {{- end }}
         args:
         - --cloud-provider=aws


### PR DESCRIPTION
Trying to install the chart with Helm I got
```
Helm install failed: unable to build kubernetes objects from release manifest: error validating "": error validating data: [ValidationError(DaemonSet.spec.template.spec.containers[0]): unknown field "limits" in io.k8s.api.core.v1.Container, ValidationError(DaemonSet.spec.template.spec.containers[0]): unknown field "requests" in io.k8s.api.core.v1.Container]
```

The daemonset manifest is wrongly indented
```
      containers:
      - name: aws-cloud-controller-manager-app
        image: "quay.io/giantswarm/aws-cloud-controller-manager:v1.24.1"
        resources: 
        limits:
          cpu: 200m
          memory: 300Mi
        requests:
          cpu: 200m
          memory: 300Mi
```