### PR TITLE
Support for running behind a proxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Added
+
+- Support for running behind a proxy.
+- Support for using `cluster-apps-operator` specific `cluster.proxy` values.
+
 ## [1.24.1-gs2] - 2023-05-01
 
 ### Fixed

--- a/helm/aws-cloud-controller-manager-app/templates/daemonset.yaml
+++ b/helm/aws-cloud-controller-manager-app/templates/daemonset.yaml
@@ -37,6 +37,22 @@ spec:
         - --secure-port={{ .Values.ports.healthcheck }}
         - --configure-cloud-routes=false
         - --v=2
+        {{- $proxy := deepCopy .Values.cluster.proxy |  mustMerge .Values.proxy }}
+        {{- if and $proxy.noProxy $proxy.http $proxy.https }}
+        env:
+        - name: NO_PROXY
+          value: {{ $proxy.noProxy }}
+        - name: no_proxy
+          value: {{ $proxy.noProxy }}
+        - name: HTTP_PROXY
+          value: {{ $proxy.http }}
+        - name: http_proxy
+          value: {{ $proxy.http }}
+        - name: HTTPS_PROXY
+          value: {{ $proxy.https }}
+        - name: https_proxy
+          value: {{ $proxy.https }}
+        {{- end }}
         securityContext:
           allowPrivilegeEscalation: false
           privileged: false

--- a/helm/aws-cloud-controller-manager-app/values.yaml
+++ b/helm/aws-cloud-controller-manager-app/values.yaml
@@ -28,3 +28,16 @@ test:
 
 verticalPodAutoscaler:
   enabled: true
+
+# set the HTTP_PROXY, HTTPS_PROXY and NO_PROXY variable
+proxy:
+  noProxy:
+  http:
+  https:
+cluster:
+  # is getting overwritten by the top level proxy if set
+  # These values are generated via cluster-apps-operator
+  proxy:
+    noProxy:
+    http:
+    https:


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/2426

When running on a cluster behind a proxy, we need to be able to pass the proxy configuration to this app. This is the same we did here https://github.com/giantswarm/aws-ebs-csi-driver-app/pull/150