### PR TITLE
Change nodeSelector to control-plane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Change the `nodeSelector` in the `DaemonSet` from `node-role.kubernetes.io/master: ""` to `node-role.kubernetes.io/control-plane: ""`.
+
 ## [1.24.1-gs3] - 2023-05-02
 
 ### Added

--- a/helm/aws-cloud-controller-manager-app/templates/daemonset.yaml
+++ b/helm/aws-cloud-controller-manager-app/templates/daemonset.yaml
@@ -25,7 +25,7 @@ spec:
       tolerations:
       - operator: "Exists"
       nodeSelector:
-        node-role.kubernetes.io/master: ""
+        node-role.kubernetes.io/control-plane: ""
       containers:
       - name: {{ .Chart.Name }}
         image: "{{ .Values.image.registry }}/{{ .Values.image.name }}:{{ .Values.image.tag }}"


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/2452

The label on the master nodes have changed in recent k8s versions.