### PR TITLE
Always install VPA CR if vpa is enabled in the values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Always install the VPA CR if `verticalPodAutoscaler.enabled` is true, no matter if the VPA CRD is present or not.
+
 ## [1.24.1-gs7] - 2023-05-11
 
 ### Fixed

--- a/helm/aws-cloud-controller-manager-app/templates/vpa.yaml
+++ b/helm/aws-cloud-controller-manager-app/templates/vpa.yaml
@@ -1,4 +1,3 @@
-{{ if .Capabilities.APIVersions.Has "autoscaling.k8s.io/v1" }}
 {{ if .Values.verticalPodAutoscaler.enabled }}
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
@@ -19,5 +18,4 @@ spec:
     name:  {{ .Values.name }}
   updatePolicy:
     updateMode: Auto
-{{ end }}
 {{ end }}


### PR DESCRIPTION
We want to make sure VPA is always installed. With the conditional, there is a race condition when the app platform tries to install this app before installing the VPA CRD app: this app will end up without the VPA and it will never be applied unless the `Chart` is manually recreated. 

[We've made this a dependency in our vintage release](https://github.com/giantswarm/releases/pull/1125).