### PR TITLE
Vpa adjustments

### DIFF
--- a/helm/aws-cloud-controller-manager-app/templates/vpa.yaml
+++ b/helm/aws-cloud-controller-manager-app/templates/vpa.yaml
@@ -11,8 +11,8 @@ spec:
     containerPolicies:
     - containerName: {{ .Chart.Name }}
       minAllowed:
-        cpu: "250m"
-        memory: "1024Mi"
+        cpu: "200m"
+        memory: "300Mi"
   targetRef:
     apiVersion: apps/v1
     kind: DaemonSet

--- a/helm/aws-cloud-controller-manager-app/templates/vpa.yaml
+++ b/helm/aws-cloud-controller-manager-app/templates/vpa.yaml
@@ -10,6 +10,8 @@ spec:
   resourcePolicy:
     containerPolicies:
     - containerName: {{ .Chart.Name }}
+      controlledValues: RequestsAndLimits
+      mode: "Auto"
       minAllowed:
         cpu: "200m"
         memory: "300Mi"

--- a/helm/aws-cloud-controller-manager-app/templates/vpa.yaml
+++ b/helm/aws-cloud-controller-manager-app/templates/vpa.yaml
@@ -11,7 +11,7 @@ spec:
     containerPolicies:
     - containerName: {{ .Chart.Name }}
       controlledValues: RequestsAndLimits
-      mode: "Auto"
+      mode: Auto
       minAllowed:
         cpu: "200m"
         memory: "300Mi"

--- a/helm/aws-cloud-controller-manager-app/templates/vpa.yaml
+++ b/helm/aws-cloud-controller-manager-app/templates/vpa.yaml
@@ -10,8 +10,9 @@ spec:
   resourcePolicy:
     containerPolicies:
     - containerName: {{ .Chart.Name }}
-      controlledValues: RequestsAndLimits
-      mode: Auto
+      minAllowed:
+        cpu: "250m"
+        memory: "1024Mi"
   targetRef:
     apiVersion: apps/v1
     kind: DaemonSet

--- a/helm/aws-cloud-controller-manager-app/templates/vpa.yaml
+++ b/helm/aws-cloud-controller-manager-app/templates/vpa.yaml
@@ -13,8 +13,8 @@ spec:
       controlledValues: RequestsAndLimits
       mode: Auto
       minAllowed:
-        cpu: "200m"
-        memory: "300Mi"
+        cpu: {{ .Values.verticalPodAutoscaler.minAllowed.cpu }}
+        memory: {{ .Values.verticalPodAutoscaler.minAllowed.memory }}
   targetRef:
     apiVersion: apps/v1
     kind: DaemonSet

--- a/helm/aws-cloud-controller-manager-app/values.yaml
+++ b/helm/aws-cloud-controller-manager-app/values.yaml
@@ -30,6 +30,9 @@ test:
 
 verticalPodAutoscaler:
   enabled: true
+  minAllowed:
+    cpu: 200m
+    memory: 300Mi
 
 # set the HTTP_PROXY, HTTPS_PROXY and NO_PROXY variable
 proxy:

--- a/helm/aws-cloud-controller-manager-app/values.yaml
+++ b/helm/aws-cloud-controller-manager-app/values.yaml
@@ -10,10 +10,12 @@ image:
   name: giantswarm/aws-cloud-controller-manager
   tag: v1.24.1
 
+# We set the limit twice as the requests so that the VPA
+# can keep the ratio when scaling
 resources:
   limits:
-    cpu: 200m
-    memory: 300Mi
+    cpu: 400m
+    memory: 600Mi
   requests:
     cpu: 200m
     memory: 300Mi


### PR DESCRIPTION
With this PR we are:
- setting a minimum amount of resources VPA is allow to scale down the daemonset.
- setting the limits to twice the requests so that the VPA can keep the ration when scaling