### PR TITLE
Reduce minimum CPU and memory requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Reduce minimum CPU and memory requests.
+
 ## [1.25.14-gs2] - 2024-01-22
 
 ### Changed

--- a/helm/aws-cloud-controller-manager-app/values.yaml
+++ b/helm/aws-cloud-controller-manager-app/values.yaml
@@ -17,8 +17,8 @@ resources:
     cpu: 400m
     memory: 600Mi
   requests:
-    cpu: 200m
-    memory: 300Mi
+    cpu: 50m
+    memory: 75Mi
 
 ports:
   healthcheck: 10267
@@ -31,8 +31,8 @@ test:
 verticalPodAutoscaler:
   enabled: true
   minAllowed:
-    cpu: 200m
-    memory: 300Mi
+    cpu: 50m
+    memory: 50Mi
 
 # set the HTTP_PROXY, HTTPS_PROXY and NO_PROXY variable
 proxy:


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/30671
Towards https://github.com/giantswarm/giantswarm/issues/30682

By default, the app uses a very small amount of the resources it requests (see https://github.com/giantswarm/cluster-aws/pull/603#issuecomment-2088447499). This PR reduces the requests and limits to be more efficient, which saves ~450m CPU and ~750Mi memory in requests across a 3 node control plane.