### PR TITLE
Update upstream version to 1.26

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Update aws-cloud-controller-manager upstream version to v1.26.11.
+
 ## [1.25.14-gs3] - 2024-05-09
 
 ### Changed

--- a/helm/aws-cloud-controller-manager-app/values.yaml
+++ b/helm/aws-cloud-controller-manager-app/values.yaml
@@ -8,7 +8,7 @@ serviceType: managed
 image:
   registry: gsoci.azurecr.io
   name: giantswarm/aws-cloud-controller-manager
-  tag: v1.26.9
+  tag: v1.26.11
 
 # We set the limit twice as the requests so that the VPA
 # can keep the ratio when scaling

--- a/helm/aws-cloud-controller-manager-app/values.yaml
+++ b/helm/aws-cloud-controller-manager-app/values.yaml
@@ -8,7 +8,7 @@ serviceType: managed
 image:
   registry: gsoci.azurecr.io
   name: giantswarm/aws-cloud-controller-manager
-  tag: v1.25.14
+  tag: v1.26.9
 
 # We set the limit twice as the requests so that the VPA
 # can keep the ratio when scaling


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/3531

### Changed

- Update aws-cloud-controller-manager to v1.26.11