### PR TITLE
Update aws-cloud-controller-manager upstream version to v1.27.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Update aws-cloud-controller-manager upstream version to v1.27.7.
+
 ## [1.26.11-gs1] - 2024-07-05
 
 ### Changed

--- a/helm/aws-cloud-controller-manager-app/values.yaml
+++ b/helm/aws-cloud-controller-manager-app/values.yaml
@@ -8,7 +8,7 @@ serviceType: managed
 image:
   registry: gsoci.azurecr.io
   name: giantswarm/aws-cloud-controller-manager
-  tag: v1.26.11
+  tag: v1.27.7
 
 # We set the limit twice as the requests so that the VPA
 # can keep the ratio when scaling


### PR DESCRIPTION
Update to latest 1.27 upstream image for k8s 1.27 