### PR TITLE
Update aws-cloud-controller-manager upstream version to v1.28.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Update aws-cloud-controller-manager upstream version to v1.28.6.
+
 ## [1.27.7-gs1] - 2024-07-09
 
 ### Changed

--- a/helm/aws-cloud-controller-manager-app/Chart.yaml
+++ b/helm/aws-cloud-controller-manager-app/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: 1.24.1
+appVersion: 1.28.6
 description: A Helm chart to run AWS Cloud Controller Manager
 home: https://github.com/giantswarm/aws-cloud-controller-manager-app
 name: aws-cloud-controller-manager-app

--- a/helm/aws-cloud-controller-manager-app/values.yaml
+++ b/helm/aws-cloud-controller-manager-app/values.yaml
@@ -8,7 +8,7 @@ serviceType: managed
 image:
   registry: gsoci.azurecr.io
   name: giantswarm/aws-cloud-controller-manager
-  tag: v1.27.7
+  tag: v1.28.6
 
 # We set the limit twice as the requests so that the VPA
 # can keep the ratio when scaling


### PR DESCRIPTION
Update to latest 1.28 upstream image (1.28.6) for k8s 1.28

Will test before merging with capa v28.
