### PR TITLE
Chart: Remove duplicate service account.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Chart: Remove duplicate service account. ([#87](https://github.com/giantswarm/aws-cloud-controller-manager-app/pull/87))
+
 ## [1.30.7-gs1] - 2025-02-17
 
 ### Changed

--- a/helm/aws-cloud-controller-manager-app/templates/rbac.yaml
+++ b/helm/aws-cloud-controller-manager-app/templates/rbac.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ .Values.name }}
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "labels.common" . | nindent 4 }}
 ---

--- a/helm/aws-cloud-controller-manager-app/templates/serviceaccount.yaml
+++ b/helm/aws-cloud-controller-manager-app/templates/serviceaccount.yaml
@@ -1,7 +1,0 @@
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: {{ .Values.name }}
-  namespace: {{ .Release.Namespace }}
-  labels:
-    {{- include "labels.common" . | nindent 4 }}


### PR DESCRIPTION
@pipo02mix I guess you missed that when changing it in https://github.com/giantswarm/aws-cloud-controller-manager-app/pull/82.