### PR TITLE
Remove deprecated application.giantswarm.io/team annotation

### DIFF
--- a/helm/aws-cloud-controller-manager-app/Chart.yaml
+++ b/helm/aws-cloud-controller-manager-app/Chart.yaml
@@ -6,7 +6,6 @@ appVersion: 1.35.0
 home: https://github.com/giantswarm/aws-cloud-controller-manager-app
 icon: https://s.giantswarm.io/app-icons/aws/2/dark.svg
 annotations:
-  application.giantswarm.io/team: phoenix
   ui.giantswarm.io/logo: https://s.giantswarm.io/app-icons/aws/2/dark.svg
   io.giantswarm.application.audience: all
   io.giantswarm.application.managed: "true"

--- a/helm/aws-cloud-controller-manager-app/templates/_helpers.tpl
+++ b/helm/aws-cloud-controller-manager-app/templates/_helpers.tpl
@@ -14,7 +14,7 @@ app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
 app.kubernetes.io/name: {{ .Values.name | quote }}
 app.kubernetes.io/instance: {{ .Release.Name | quote }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
-application.giantswarm.io/team: {{ index .Chart.Annotations "application.giantswarm.io/team" | quote }}
+application.giantswarm.io/team: {{ index .Chart.Annotations "io.giantswarm.application.team" | quote }}
 giantswarm.io/service-type: "{{ .Values.serviceType }}"
 helm.sh/chart: {{ include "chart" . | quote }}
 kubernetes.io/cluster-service: "true"


### PR DESCRIPTION
Remove `application.giantswarm.io/team` annotation from `Chart.yaml` and update `_helpers.tpl` to read the team from `io.giantswarm.application.team` instead.

This follows the same pattern applied across other Phoenix apps as part of the migration to `io.giantswarm.application.*` annotations.

Relates to giantswarm/giantswarm#35731